### PR TITLE
Sécurisation au premier boot du serveur

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -125,6 +125,7 @@ minetest.register_globalstep(function(dtime)
 		if mversion<version then
 			local serveuradresse = minetest.deserialize(minetest.get_meta(TELEPORT_SERVEUR):get_string("lesadresse"))
 			local nouveauxserveuxadresse={}
+			if not serveuradresse then return end
 			for key, val in pairs(serveuradresse) do
 				--socle
 				local adresse = minetest.deserialize(minetest.get_meta(val):get_string("adresse"))


### PR DESCRIPTION
- Lors du premier boot du serveur, le mod ne peut pas récupérer certaines
  informations stockées sur la map dans des métadonnées de nodes (qui
  n'ont pas encore été posés), ce qui causait le crash. La (malheureuse)
  ligne que j'ai rajouté empêche ce comportement dangereux, et une fois le
  bloc serveur posé, la fonction qui causait le crash fonctionnera.

Cette pull-request permettra ainsi de rendre le mod non seulement utilisable par tous, mais aussi sûr. Je suggère cependant l'ajout d'une notice, pour expliquer comment installer sur la map les composants utiles au mod.
